### PR TITLE
Added 'callback' parameter to custom activities.

### DIFF
--- a/Classes/DkNappSocialModule.m
+++ b/Classes/DkNappSocialModule.m
@@ -741,6 +741,7 @@ MAKE_SYSTEM_PROP(ACTIVITY_CUSTOM, 100);
 				[TiUtils stringValue:@"title" properties:activityDictionary def:@""], @"title",
 				[self findImage:activityImage], @"image",
 				self, @"module",
+				[activityDictionary objectForKey:@"callback"], @"callback",
 			nil];
 
             NappCustomActivity *nappActivity = [[NappCustomActivity alloc] initWithSettings:activityStyling];

--- a/Classes/NappCustomActivity.m
+++ b/Classes/NappCustomActivity.m
@@ -15,6 +15,7 @@
 @property (strong, nonatomic) NSString *type;
 @property (strong, nonatomic) UIImage *image;
 @property (strong, nonatomic) TiModule *module;
+@property (strong, nonatomic) KrollCallback *callback;
 
 @end
 
@@ -51,6 +52,10 @@
 - (UIViewController *)activityViewController {
     NSDictionary *event = [NSDictionary dictionaryWithObjectsAndKeys: self.title,@"title", self.type,@"type", nil];
     [self.module fireEvent:@"customActivity" withObject:event];
+    if (self.callback) {
+        NSArray* array = [NSArray arrayWithObjects: event, nil];
+        [self.callback call:array thisObject:nil];
+    }
     [self activityDidFinish:YES];
     return nil;
 }
@@ -69,6 +74,7 @@
         self.title = [dict objectForKey:@"title"];
         self.image = [dict objectForKey:@"image"];
         self.module = [dict objectForKey:@"module"];
+        self.callback = [dict objectForKey:@"callback"];
     }
     return(self);
 }

--- a/README.md
+++ b/README.md
@@ -192,7 +192,10 @@ Social.activityView({
 	{
 		title:"Custom Share",
 		type:"hello.world",
-		image:"pin.png"
+		image:"pin.png",
+		callback: function(e) {
+			alert("You chose me!");
+		}
 	},
 	{
 		title:"Open in Safari",


### PR DESCRIPTION
I have added a KrollCallback parameter to custom activities, this way the activity can be handled more easily in the context of the call to TiSocial.activityView call, instead of using a global event listener and risk leaking memory. 
