### PR TITLE
Titanium 3.4.X and iOS 8 Bug

### DIFF
--- a/Classes/DkNappSocialModule.m
+++ b/Classes/DkNappSocialModule.m
@@ -210,7 +210,7 @@ MAKE_SYSTEM_PROP(ACTIVITY_CUSTOM, 100);
 /*
  * Accounts
  */
--(id)twitterAccountList:(id)args
+-(void)twitterAccountList:(id)args
 {
     if(accountStore == nil){
         accountStore =  [[ACAccountStore alloc] init];


### PR DESCRIPTION
With the release of  SDK 3.4.X, SDK expected to return an "id" value from twitterAccountList method and there is no return so it crashes. This small fix removes the crash bug.
